### PR TITLE
prepare 5.10.0 release

### DIFF
--- a/src/LaunchDarkly.ServerSdk/ILdClient.cs
+++ b/src/LaunchDarkly.ServerSdk/ILdClient.cs
@@ -8,6 +8,10 @@ namespace LaunchDarkly.Client
     /// <summary>
     /// Interface defining the public methods of <see cref="LdClient"/>.
     /// </summary>
+    /// <remarks>
+    /// See also <see cref="ILdClientExtensions"/>, which provides convenience methods that build upon
+    /// this interface.
+    /// </remarks>
 #pragma warning disable 618
     public interface ILdClient : ILdCommonClient
 #pragma warning restore 618

--- a/src/LaunchDarkly.ServerSdk/ILdClientExtensions.cs
+++ b/src/LaunchDarkly.ServerSdk/ILdClientExtensions.cs
@@ -82,7 +82,7 @@ namespace LaunchDarkly.Client
                 }
                 catch (System.ArgumentException)
                 {
-                    return new EvaluationDetail<T>(defaultValue, stringDetail.VariationIndex, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+                    return new EvaluationDetail<T>(defaultValue, stringDetail.VariationIndex, EvaluationReason.ErrorReason(EvaluationErrorKind.WRONG_TYPE));
                 }
             }
             return new EvaluationDetail<T>(defaultValue, stringDetail.VariationIndex, stringDetail.Reason);

--- a/src/LaunchDarkly.ServerSdk/ILdClientExtensions.cs
+++ b/src/LaunchDarkly.ServerSdk/ILdClientExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+
+namespace LaunchDarkly.Client
+{
+    /// <summary>
+    /// Convenience methods that extend the <see cref="ILdClient"/> interface.
+    /// </summary>
+    /// <remarks>
+    /// These are implemented outside of <see cref="ILdClient"/> and <see cref="LdClient"/> because they do not
+    /// rely on any implementation details of <see cref="LdClient"/>; they are decorators that would work equally
+    /// well with a stub or test implementation of the interface.
+    /// </remarks>
+    public static class ILdClientExtensions
+    {
+        /// <summary>
+        /// Equivalent to <see cref="ILdClient.StringVariation(string, User, string)"/>, but converts the
+        /// flag's string value to an enum value.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the flag has a value that is not one of the allowed enum value names, or is not a string,
+        /// <c>defaultValue</c> is returned.
+        /// </para>
+        /// <para>
+        /// Note that there is no type constraint to guarantee that T really is an enum type, because that is
+        /// a C# 7.3 feature that is unavailable in older versions of .NET Standard. If you try to use a
+        /// non-enum type, you will simply receive the default value back.
+        /// </para>
+        /// </remarks>
+        /// <typeparam name="T">the enum type</typeparam>
+        /// <param name="client">the client instance</param>
+        /// <param name="key">the unique feature key for the feature flag</param>
+        /// <param name="user">the end user requesting the flag</param>
+        /// <param name="defaultValue">the default value of the flag (as an enum value)</param>
+        /// <returns>the variation for the given user, or <c>defaultValue</c> if the flag cannot
+        /// be evaluated or does not have a valid enum value</returns>
+        public static T EnumVariation<T>(this ILdClient client, string key, User user, T defaultValue)
+        {
+            var stringVal = client.StringVariation(key, user, defaultValue.ToString());
+            if (stringVal != null)
+            {
+                try
+                {
+                    return (T)System.Enum.Parse(typeof(T), stringVal, true);
+                }
+                catch (System.ArgumentException)
+                { }
+            }
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Equivalent to <see cref="ILdClient.StringVariationDetail(string, User, string)"/>, but converts the
+        /// flag's string value to an enum value.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the flag has a value that is not one of the allowed enum value names, or is not a string,
+        /// <c>defaultValue</c> is returned.
+        /// </para>
+        /// <para>
+        /// Note that there is no type constraint to guarantee that T really is an enum type, because that is
+        /// a C# 7.3 feature that is unavailable in older versions of .NET Standard. If you try to use a
+        /// non-enum type, you will simply receive the default value back.
+        /// </para>
+        /// </remarks>
+        /// <typeparam name="T">the enum type</typeparam>
+        /// <param name="client">the client instance</param>
+        /// <param name="key">the unique feature key for the feature flag</param>
+        /// <param name="user">the end user requesting the flag</param>
+        /// <param name="defaultValue">the default value of the flag (as an enum value)</param>
+        /// <returns>an <see cref="EvaluationDetail{T}"/> object</returns>
+        public static EvaluationDetail<T> EnumVariationDetail<T>(this ILdClient client, string key, User user, T defaultValue)
+        {
+            var stringDetail = client.StringVariationDetail(key, user, defaultValue.ToString());
+            if (stringDetail.Value != null)
+            {
+                try
+                {
+                    var enumValue = (T)System.Enum.Parse(typeof(T), stringDetail.Value, true);
+                    return new EvaluationDetail<T>(enumValue, stringDetail.VariationIndex, stringDetail.Reason);
+                }
+                catch (System.ArgumentException)
+                {
+                    return new EvaluationDetail<T>(defaultValue, stringDetail.VariationIndex, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+                }
+            }
+            return new EvaluationDetail<T>(defaultValue, stringDetail.VariationIndex, stringDetail.Reason);
+        }
+    }
+}

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -15,10 +15,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.1" />
+    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.2-beta1" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.1" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.2-beta1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -15,10 +15,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.2-beta1" />
+    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.2-beta1" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.7.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.1" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.7.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.0" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.8.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="LaunchDarkly.CommonSdk.StrongName" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />

--- a/src/LaunchDarkly.ServerSdk/LdClient.cs
+++ b/src/LaunchDarkly.ServerSdk/LdClient.cs
@@ -280,7 +280,7 @@ namespace LaunchDarkly.Client
                 {
                     Log.ErrorFormat("Exception caught for feature flag \"{0}\" when evaluating all flags: {1}", flag.Key, Util.ExceptionMessage(e));
                     Log.Debug(e.ToString(), e);
-                    EvaluationReason reason = new EvaluationReason.Error(EvaluationErrorKind.EXCEPTION);
+                    EvaluationReason reason = EvaluationReason.ErrorReason(EvaluationErrorKind.EXCEPTION);
                     state.AddFlag(flag, null, null, withReasons ? reason : null, detailsOnlyIfTracked);
                 }
             }
@@ -301,7 +301,7 @@ namespace LaunchDarkly.Client
                 {
                     Log.Warn("Flag evaluation before client initialized; feature store unavailable, returning default value");
                     return new EvaluationDetail<T>(defaultValueOfType, null,
-                        new EvaluationReason.Error(EvaluationErrorKind.CLIENT_NOT_READY));
+                        EvaluationReason.ErrorReason(EvaluationErrorKind.CLIENT_NOT_READY));
                 }
             }
 
@@ -316,7 +316,7 @@ namespace LaunchDarkly.Client
                     _eventProcessor.SendEvent(eventFactory.NewUnknownFeatureRequestEvent(featureKey, user, defaultValue,
                         EvaluationErrorKind.FLAG_NOT_FOUND));
                     return new EvaluationDetail<T>(defaultValueOfType, null,
-                        new EvaluationReason.Error(EvaluationErrorKind.FLAG_NOT_FOUND));
+                        EvaluationReason.ErrorReason(EvaluationErrorKind.FLAG_NOT_FOUND));
                 }
 
                 if (user == null || user.Key == null)
@@ -325,7 +325,7 @@ namespace LaunchDarkly.Client
                     _eventProcessor.SendEvent(eventFactory.NewDefaultFeatureRequestEvent(featureFlag, user, defaultValue,
                         EvaluationErrorKind.USER_NOT_SPECIFIED));
                     return new EvaluationDetail<T>(defaultValueOfType, null,
-                        new EvaluationReason.Error(EvaluationErrorKind.USER_NOT_SPECIFIED));
+                        EvaluationReason.ErrorReason(EvaluationErrorKind.USER_NOT_SPECIFIED));
                 }
                 
                 FeatureFlag.EvalResult evalResult = featureFlag.Evaluate(user, _featureStore, eventFactory);
@@ -355,7 +355,7 @@ namespace LaunchDarkly.Client
                         _eventProcessor.SendEvent(eventFactory.NewDefaultFeatureRequestEvent(featureFlag, user,
                             defaultValue, EvaluationErrorKind.WRONG_TYPE));
                         return new EvaluationDetail<T>(defaultValueOfType, null,
-                            new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+                            EvaluationReason.ErrorReason(EvaluationErrorKind.WRONG_TYPE));
                     }
                     returnDetail = new EvaluationDetail<T>(converter.ToType(evalDetail.Value),
                         evalDetail.VariationIndex, evalDetail.Reason);
@@ -371,7 +371,7 @@ namespace LaunchDarkly.Client
                      featureKey,
                      user.Key);
                 Log.Debug(e.ToString(), e);
-                var reason = new EvaluationReason.Error(EvaluationErrorKind.EXCEPTION);
+                var reason = EvaluationReason.ErrorReason(EvaluationErrorKind.EXCEPTION);
                 if (featureFlag == null)
                 {
                     _eventProcessor.SendEvent(eventFactory.NewUnknownFeatureRequestEvent(featureKey, user,

--- a/test/LaunchDarkly.ServerSdk.Tests/FeatureFlagTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/FeatureFlagTest.cs
@@ -25,7 +25,7 @@ namespace LaunchDarkly.Tests
                 .Build();
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Of("off"), 1, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Of("off"), 1, EvaluationReason.OffReason);
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -40,7 +40,7 @@ namespace LaunchDarkly.Tests
                 .Build();
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Null, null, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Null, null, EvaluationReason.OffReason);
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -57,7 +57,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -74,7 +74,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -90,7 +90,7 @@ namespace LaunchDarkly.Tests
                 .Build();
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.Fallthrough.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.FallthroughReason);
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -107,7 +107,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -124,7 +124,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -141,7 +141,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -158,7 +158,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -176,7 +176,7 @@ namespace LaunchDarkly.Tests
             var result = f0.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Of("off"), 1,
-                new EvaluationReason.PrerequisiteFailed("feature1"));
+                EvaluationReason.PrerequisiteFailedReason("feature1"));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -204,7 +204,7 @@ namespace LaunchDarkly.Tests
             var result = f0.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Of("off"), 1,
-                new EvaluationReason.PrerequisiteFailed("feature1"));
+                EvaluationReason.PrerequisiteFailedReason("feature1"));
             Assert.Equal(expected, result.Result);
 
             Assert.Equal(1, result.PrerequisiteEvents.Count);
@@ -237,7 +237,7 @@ namespace LaunchDarkly.Tests
             var result = f0.Evaluate(baseUser, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Of("off"), 1,
-                new EvaluationReason.PrerequisiteFailed("feature1"));
+                EvaluationReason.PrerequisiteFailedReason("feature1"));
             Assert.Equal(expected, result.Result);
 
             Assert.Equal(1, result.PrerequisiteEvents.Count);
@@ -269,7 +269,7 @@ namespace LaunchDarkly.Tests
 
             var result = f0.Evaluate(baseUser, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.Fallthrough.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.FallthroughReason);
             Assert.Equal(expected, result.Result);
 
             Assert.Equal(1, result.PrerequisiteEvents.Count);
@@ -309,7 +309,7 @@ namespace LaunchDarkly.Tests
 
             var result = f0.Evaluate(baseUser, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.Fallthrough.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Of("fall"), 0, EvaluationReason.FallthroughReason);
             Assert.Equal(expected, result.Result);
 
             Assert.Equal(2, result.PrerequisiteEvents.Count);
@@ -340,7 +340,7 @@ namespace LaunchDarkly.Tests
             var user = User.WithKey("userkey");
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
-            var expected = new EvaluationDetail<LdValue>(LdValue.Of("on"), 2, EvaluationReason.TargetMatch.Instance);
+            var expected = new EvaluationDetail<LdValue>(LdValue.Of("on"), 2, EvaluationReason.TargetMatchReason);
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -358,7 +358,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Of("on"), 2,
-                new EvaluationReason.RuleMatch(1, "ruleid1"));
+                EvaluationReason.RuleMatchReason(1, "ruleid1"));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -374,7 +374,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -390,7 +390,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -406,7 +406,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }
@@ -423,7 +423,7 @@ namespace LaunchDarkly.Tests
             var result = f.Evaluate(user, featureStore, EventFactory.Default);
 
             var expected = new EvaluationDetail<LdValue>(LdValue.Null, null,
-                new EvaluationReason.Error(EvaluationErrorKind.MALFORMED_FLAG));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.MALFORMED_FLAG));
             Assert.Equal(expected, result.Result);
             Assert.Equal(0, result.PrerequisiteEvents.Count);
         }

--- a/test/LaunchDarkly.ServerSdk.Tests/FeatureFlagsStateTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/FeatureFlagsStateTest.cs
@@ -46,9 +46,9 @@ namespace LaunchDarkly.Tests
         {
             var state = new FeatureFlagsState(true);
             var flag = new FeatureFlagBuilder("key").Build();
-            state.AddFlag(flag, new JValue("value"), 1, EvaluationReason.Fallthrough.Instance, false);
+            state.AddFlag(flag, new JValue("value"), 1, EvaluationReason.FallthroughReason, false);
 
-            Assert.Equal(EvaluationReason.Fallthrough.Instance, state.GetFlagReason("key"));
+            Assert.Equal(EvaluationReason.FallthroughReason, state.GetFlagReason("key"));
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace LaunchDarkly.Tests
             var flag2 = new FeatureFlagBuilder("key2").Version(200)
                 .TrackEvents(true).DebugEventsUntilDate(1000).Build();
             state.AddFlag(flag1, new JValue("value1"), 0, null, false);
-            state.AddFlag(flag2, new JValue("value2"), 1, EvaluationReason.Fallthrough.Instance, false);
+            state.AddFlag(flag2, new JValue("value2"), 1, EvaluationReason.FallthroughReason, false);
 
             var expectedString = @"{""key1"":""value1"",""key2"":""value2"",
                 ""$flagsState"":{
@@ -139,7 +139,7 @@ namespace LaunchDarkly.Tests
             var flag2 = new FeatureFlagBuilder("key2").Version(200)
                 .TrackEvents(true).DebugEventsUntilDate(1000).Build();
             state.AddFlag(flag1, new JValue("value1"), 0, null, false);
-            state.AddFlag(flag2, new JValue("value2"), 1, EvaluationReason.Fallthrough.Instance, false);
+            state.AddFlag(flag2, new JValue("value2"), 1, EvaluationReason.FallthroughReason, false);
 
             var jsonString = JsonConvert.SerializeObject(state);
             var state1 = JsonConvert.DeserializeObject<FeatureFlagsState>(jsonString);

--- a/test/LaunchDarkly.ServerSdk.Tests/ILdClientExtensionsTests.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/ILdClientExtensionsTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using LaunchDarkly.Client;
+using Newtonsoft.Json.Linq;
+using Moq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class ILdClientExtensionsTests
+    {
+        private static readonly User defaultUser = User.WithKey("userkey");
+
+        enum MyEnum
+        {
+            Red,
+            Green,
+            Blue
+        };
+
+        [Fact]
+        public void EnumVariationConvertsStringToEnum()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariation("key", defaultUser, "Blue")).Returns("Green");
+            var client = clientMock.Object;
+
+            var result = client.EnumVariation("key", defaultUser, MyEnum.Blue);
+            Assert.Equal(MyEnum.Green, result);
+        }
+        
+        [Fact]
+        public void EnumVariationReturnsDefaultValueForInvalidFlagValue()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariation("key", defaultUser, "Blue")).Returns("not-a-color");
+            var client = clientMock.Object;
+
+            var defaultValue = MyEnum.Blue;
+            var result = client.EnumVariation("key", defaultUser, defaultValue);
+            Assert.Equal(MyEnum.Blue, defaultValue);
+        }
+
+        [Fact]
+        public void EnumVariationReturnsDefaultValueForNullFlagValue()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariation("key", defaultUser, "Blue")).Returns((string)null);
+            var client = clientMock.Object;
+
+            var defaultValue = MyEnum.Blue;
+            var result = client.EnumVariation("key", defaultUser, defaultValue);
+            Assert.Equal(defaultValue, result);
+        }
+
+        [Fact]
+        public void EnumVariationReturnsDefaultValueForNonEnumType()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariation("key", defaultUser, "Blue")).Returns("Green");
+            var client = clientMock.Object;
+
+            var defaultValue = "this is a string, not an enum";
+            var result = client.EnumVariation("key", defaultUser, defaultValue);
+            Assert.Equal(defaultValue, result);
+        }
+
+        [Fact]
+        public void EnumVariationDetailConvertsStringToEnum()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
+                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.Fallthrough.Instance));
+            var client = clientMock.Object;
+
+            var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Green, 1, EvaluationReason.Fallthrough.Instance);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EnumVariationDetailReturnsDefaultValueForInvalidFlagValue()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
+                .Returns(new EvaluationDetail<string>("not-a-color", 1, EvaluationReason.Fallthrough.Instance));
+            var client = clientMock.Object;
+
+            var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EnumVariationDetailReturnsDefaultValueForNullFlagValue()
+        {
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
+                .Returns(new EvaluationDetail<string>(null, 1, EvaluationReason.Fallthrough.Instance));
+            var client = clientMock.Object;
+
+            var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, EvaluationReason.Fallthrough.Instance);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EnumVariationDetailReturnsDefaultValueForNonEnumType()
+        {
+            var defaultValue = "this is a string, not an enum";
+            var clientMock = new Mock<ILdClient>();
+            clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, defaultValue))
+                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.Fallthrough.Instance));
+            var client = clientMock.Object;
+
+            var result = client.EnumVariationDetail("key", defaultUser, defaultValue);
+            var expected = new EvaluationDetail<string>(defaultValue, 1, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+            Assert.Equal(expected, result);
+        }
+
+    }
+}

--- a/test/LaunchDarkly.ServerSdk.Tests/ILdClientExtensionsTests.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/ILdClientExtensionsTests.cs
@@ -72,11 +72,11 @@ namespace LaunchDarkly.Tests
         {
             var clientMock = new Mock<ILdClient>();
             clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
-                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.Fallthrough.Instance));
+                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.FallthroughReason));
             var client = clientMock.Object;
 
             var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
-            var expected = new EvaluationDetail<MyEnum>(MyEnum.Green, 1, EvaluationReason.Fallthrough.Instance);
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Green, 1, EvaluationReason.FallthroughReason);
             Assert.Equal(expected, result);
         }
 
@@ -85,11 +85,11 @@ namespace LaunchDarkly.Tests
         {
             var clientMock = new Mock<ILdClient>();
             clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
-                .Returns(new EvaluationDetail<string>("not-a-color", 1, EvaluationReason.Fallthrough.Instance));
+                .Returns(new EvaluationDetail<string>("not-a-color", 1, EvaluationReason.FallthroughReason));
             var client = clientMock.Object;
 
             var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
-            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, EvaluationReason.ErrorReason(EvaluationErrorKind.WRONG_TYPE));
             Assert.Equal(expected, result);
         }
 
@@ -98,11 +98,11 @@ namespace LaunchDarkly.Tests
         {
             var clientMock = new Mock<ILdClient>();
             clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, "Blue"))
-                .Returns(new EvaluationDetail<string>(null, 1, EvaluationReason.Fallthrough.Instance));
+                .Returns(new EvaluationDetail<string>(null, 1, EvaluationReason.FallthroughReason));
             var client = clientMock.Object;
 
             var result = client.EnumVariationDetail("key", defaultUser, MyEnum.Blue);
-            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, EvaluationReason.Fallthrough.Instance);
+            var expected = new EvaluationDetail<MyEnum>(MyEnum.Blue, 1, EvaluationReason.FallthroughReason);
             Assert.Equal(expected, result);
         }
 
@@ -112,11 +112,11 @@ namespace LaunchDarkly.Tests
             var defaultValue = "this is a string, not an enum";
             var clientMock = new Mock<ILdClient>();
             clientMock.Setup(c => c.StringVariationDetail("key", defaultUser, defaultValue))
-                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.Fallthrough.Instance));
+                .Returns(new EvaluationDetail<string>("Green", 1, EvaluationReason.FallthroughReason));
             var client = clientMock.Object;
 
             var result = client.EnumVariationDetail("key", defaultUser, defaultValue);
-            var expected = new EvaluationDetail<string>(defaultValue, 1, new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+            var expected = new EvaluationDetail<string>(defaultValue, 1, EvaluationReason.ErrorReason(EvaluationErrorKind.WRONG_TYPE));
             Assert.Equal(expected, result);
         }
 

--- a/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.1" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />

--- a/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />

--- a/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.7.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />

--- a/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.Tests/LaunchDarkly.ServerSdk.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.8.0" />
+    <PackageReference Include="LaunchDarkly.CommonSdk" Version="2.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />

--- a/test/LaunchDarkly.ServerSdk.Tests/LdClientEvaluationTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/LdClientEvaluationTest.cs
@@ -55,7 +55,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build());
 
-            var expected = new EvaluationDetail<bool>(true, 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<bool>(true, 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.BoolVariationDetail("key", user, false));
         }
         
@@ -115,7 +115,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(new JValue(2)).Build());
 
-            var expected = new EvaluationDetail<int>(2, 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<int>(2, 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.IntVariationDetail("key", user, 1));
         }
 
@@ -158,7 +158,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(new JValue(2.5f)).Build());
 
-            var expected = new EvaluationDetail<float>(2.5f, 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<float>(2.5f, 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.FloatVariationDetail("key", user, 1.0f));
         }
 
@@ -207,7 +207,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(new JValue("b")).Build());
 
-            var expected = new EvaluationDetail<string>("b", 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<string>("b", 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.StringVariationDetail("key", user, "a"));
         }
 
@@ -235,7 +235,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(data.InnerValue).Build());
 
-            var expected = new EvaluationDetail<LdValue>(data, 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<LdValue>(data, 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.JsonVariationDetail("key", user, LdValue.Of(42)));
         }
 
@@ -266,7 +266,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(data).Build());
 #pragma warning disable 0618
-            var expected = new EvaluationDetail<JToken>(data, 0, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<JToken>(data, 0, EvaluationReason.OffReason);
             Assert.Equal(expected, client.JsonVariationDetail("key", user, new JValue(42)));
 #pragma warning restore 0618
         }
@@ -275,7 +275,7 @@ namespace LaunchDarkly.Tests
         public void VariationDetailReturnsDefaultForUnknownFlag()
         {
             var expected = new EvaluationDetail<string>("default", null,
-                new EvaluationReason.Error(EvaluationErrorKind.FLAG_NOT_FOUND));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.FLAG_NOT_FOUND));
             Assert.Equal(expected, client.StringVariationDetail("key", null, "default"));
         }
         
@@ -286,7 +286,7 @@ namespace LaunchDarkly.Tests
                 new FeatureFlagBuilder("key").OffWithValue(new JValue("b")).Build());
 
             var expected = new EvaluationDetail<string>("default", null,
-                new EvaluationReason.Error(EvaluationErrorKind.USER_NOT_SPECIFIED));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.USER_NOT_SPECIFIED));
             Assert.Equal(expected, client.StringVariationDetail("key", null, "default"));
         }
 
@@ -297,7 +297,7 @@ namespace LaunchDarkly.Tests
                 new FeatureFlagBuilder("key").OffWithValue(new JValue("b")).Build());
 
             var expected = new EvaluationDetail<string>("default", null,
-                new EvaluationReason.Error(EvaluationErrorKind.USER_NOT_SPECIFIED));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.USER_NOT_SPECIFIED));
             Assert.Equal(expected, client.StringVariationDetail("key", User.WithKey(null), "default"));
         }
 
@@ -307,7 +307,7 @@ namespace LaunchDarkly.Tests
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").On(false).OffVariation(null).Build());
 
-            var expected = new EvaluationDetail<string>("default", null, EvaluationReason.Off.Instance);
+            var expected = new EvaluationDetail<string>("default", null, EvaluationReason.OffReason);
             Assert.Equal(expected, client.StringVariationDetail("key", user, "default"));
         }
 
@@ -318,7 +318,7 @@ namespace LaunchDarkly.Tests
                 new FeatureFlagBuilder("key").OffWithValue(new JValue("wrong")).Build());
 
             var expected = new EvaluationDetail<int>(1, null,
-                new EvaluationReason.Error(EvaluationErrorKind.WRONG_TYPE));
+                EvaluationReason.ErrorReason(EvaluationErrorKind.WRONG_TYPE));
             Assert.Equal(expected, client.IntVariationDetail("key", user, 1));
         }
 

--- a/test/LaunchDarkly.ServerSdk.Tests/LdClientEventTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/LdClientEventTest.cs
@@ -303,7 +303,7 @@ namespace LaunchDarkly.Tests
             Assert.Equal(1, eventSink.Events.Count);
             var e = Assert.IsType<FeatureRequestEvent>(eventSink.Events[0]);
             Assert.True(e.TrackEvents);
-            Assert.Equal(new EvaluationReason.RuleMatch(0, "rule-id"), e.Reason);
+            Assert.Equal(EvaluationReason.RuleMatchReason(0, "rule-id"), e.Reason);
         }
 
         [Fact]
@@ -351,7 +351,7 @@ namespace LaunchDarkly.Tests
             Assert.Equal(1, eventSink.Events.Count);
             var e = Assert.IsType<FeatureRequestEvent>(eventSink.Events[0]);
             Assert.True(e.TrackEvents);
-            Assert.Equal(EvaluationReason.Fallthrough.Instance, e.Reason);
+            Assert.Equal(EvaluationReason.FallthroughReason, e.Reason);
         }
 
         [Fact]

--- a/test/LaunchDarkly.ServerSdk.Tests/PollingProcessorTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/PollingProcessorTest.cs
@@ -106,7 +106,7 @@ namespace LaunchDarkly.Tests
             using (PollingProcessor pp = new PollingProcessor(_config, _featureRequestor, _featureStore))
             {
                 var initTask = ((IUpdateProcessor)pp).Start();
-                bool completed = initTask.Wait(TimeSpan.FromMilliseconds(500));
+                bool completed = initTask.Wait(TimeSpan.FromMilliseconds(1000));
                 Assert.True(completed);
                 Assert.False(((IUpdateProcessor)pp).Initialized());
             }


### PR DESCRIPTION
## [5.10.0] - 2019-11-12
### Added:
- Added `ILdClient` extension methods `EnumVariation` and `EnumVariationDetail`, which convert strings to enums.
- Added `LaunchDarkly.Logging.ConsoleAdapter` as a convenience for quickly enabling console logging; this is equivalent to `Common.Logging.Simple.ConsoleOutLoggerFactoryAdapter`, but the latter is not available on some platforms.
- `LdValue` helpers for dealing with array/object values, without having to use an intermediate `List` or `Dictionary`: `BuildArray`, `BuildObject`, `Count`, `Get`.
- `LdValue.Parse()`. It is also possible to use `Newtonsoft.Json.JsonConvert` to parse or serialize `LdValue`, but since the implementation may change in the future, using the type's own methods is preferable.

### Changed:
- `EvaluationReason` properties all exist on the base class now, so for instance you do not need to cast to `RuleMatch` to get the `RuleId` property. This is in preparation for a future API change in which `EvaluationReason` will become a struct instead of a base class.

### Fixed:
- Improved memory usage and performance when processing analytics events: the SDK now encodes event data to JSON directly, instead of creating intermediate objects and serializing them via reflection.
- `LdValue.Equals()` incorrectly returned true for object (dictionary) values that were not equal.

### Deprecated:
- `EvaluationReason` subclasses. Use only the base class properties and methods to ensure compatibility with future versions.
