### PR TITLE
Providing option to overwrite duplicate keys in FileDataSource

### DIFF
--- a/src/LaunchDarkly.ServerSdk/Files/DuplicateKeysHandling.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/DuplicateKeysHandling.cs
@@ -1,0 +1,18 @@
+﻿namespace LaunchDarkly.Client.Files
+{
+    /// <summary>
+    /// Determines how duplicate versioned data keys are handled.
+    /// </summary>
+    public enum DuplicateKeysHandling
+    {
+        /// <summary>
+        /// An exception will be thrown if keys are duplicated across files.
+        /// </summary>
+        Throw,
+
+        /// <summary>
+        /// Keys will be overwritten if duplicate has a newer version.
+        /// </summary>
+        OverwriteIfNewerVersion
+    }
+}

--- a/src/LaunchDarkly.ServerSdk/Files/FileDataSource.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FileDataSource.cs
@@ -15,16 +15,18 @@ namespace LaunchDarkly.Client.Files
         private readonly IDisposable _reloader;
         private readonly FlagFileParser _parser;
         private readonly bool _skipMissingPaths;
+        private readonly DuplicateKeysHandling _duplicateKeysHandling;
         private volatile bool _started;
         private volatile bool _loadedValidData;
 
         public FileDataSource(IFeatureStore featureStore, List<string> paths, bool autoUpdate, TimeSpan pollInterval,
-            Func<string, object> alternateParser, bool skipMissingPaths)
+            Func<string, object> alternateParser, bool skipMissingPaths, DuplicateKeysHandling duplicateKeysHandling)
         {
             _featureStore = featureStore;
             _paths = new List<string>(paths);
             _parser = new FlagFileParser(alternateParser);
             _skipMissingPaths = skipMissingPaths;
+            _duplicateKeysHandling = duplicateKeysHandling;
             if (autoUpdate)
             {
                 try
@@ -88,7 +90,7 @@ namespace LaunchDarkly.Client.Files
                 {
                     var content = ReadFileContent(path);
                     var data = _parser.Parse(content);
-                    data.AddToData(allData);
+                    data.AddToData(allData, _duplicateKeysHandling);
                 }
                 catch (FileNotFoundException) when (_skipMissingPaths)
                 {

--- a/src/LaunchDarkly.ServerSdk/Files/FileDataSourceFactory.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FileDataSourceFactory.cs
@@ -24,6 +24,7 @@ namespace LaunchDarkly.Client.Files
         private TimeSpan _pollInterval = DefaultPollInterval;
         private Func<string, object> _parser = null;
         private bool _skipMissingPaths = false;
+        private DuplicateKeysHandling _duplicateKeysHandling = DuplicateKeysHandling.Throw;
 
         /// <summary>
         /// Adds any number of source files for loading flag data, specifying each file path as a string.
@@ -117,6 +118,22 @@ namespace LaunchDarkly.Client.Files
         }
 
         /// <summary>
+        /// Specifies how to handle keys that are duplicated across files.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default, the file data source will throw if keys are duplicated across files.
+        /// </para>
+        /// </remarks>
+        /// <param name="duplicateKeysHandling">how duplicate keys should be handled</param>
+        /// <returns>the same factory object</returns>
+        public FileDataSourceFactory WithDuplicateKeysHandling(DuplicateKeysHandling duplicateKeysHandling)
+        {
+            _duplicateKeysHandling = duplicateKeysHandling;
+            return this;
+        }
+
+        /// <summary>
         /// Specifies how often to poll for file changes if polling is necessary.
         /// </summary>
         /// <remarks>
@@ -151,7 +168,8 @@ namespace LaunchDarkly.Client.Files
         /// <returns>the component instance</returns>
         public IUpdateProcessor CreateUpdateProcessor(Configuration config, IFeatureStore featureStore)
         {
-            return new FileDataSource(featureStore, _paths, _autoUpdate, _pollInterval, _parser, _skipMissingPaths);
+            return new FileDataSource(featureStore, _paths, _autoUpdate, _pollInterval, _parser, _skipMissingPaths,
+                _duplicateKeysHandling);
         }
     }
 }

--- a/src/LaunchDarkly.ServerSdk/Files/FlagFileData.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FlagFileData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -6,7 +7,7 @@ namespace LaunchDarkly.Client.Files
 {
     // Represents the data structure that we parse files into, and provides the logic for
     // transferring its contents into the format used by the feature store.
-    class FlagFileData
+    internal sealed class FlagFileData
     {
         [JsonProperty(PropertyName = "flags", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, JToken> Flags { get; set; }
@@ -17,33 +18,34 @@ namespace LaunchDarkly.Client.Files
         [JsonProperty(PropertyName = "segments", NullValueHandling = NullValueHandling.Ignore)]
         public Dictionary<string, JToken> Segments { get; set; }
 
-        public void AddToData(IDictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> allData)
+        public void AddToData(IDictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> allData,
+            DuplicateKeysHandling duplicateKeysHandling)
         {
             if (Flags != null)
             {
                 foreach (KeyValuePair<string, JToken> e in Flags)
                 {
-                    AddItem(allData, VersionedDataKind.Features, FlagFactory.FlagFromJson(e.Value));
+                    AddItem(allData, VersionedDataKind.Features, FlagFactory.FlagFromJson(e.Value), duplicateKeysHandling);
                 }
             }
             if (FlagValues != null)
             {
                 foreach (KeyValuePair<string, JToken> e in FlagValues)
                 {
-                    AddItem(allData, VersionedDataKind.Features, FlagFactory.FlagWithValue(e.Key, e.Value));
+                    AddItem(allData, VersionedDataKind.Features, FlagFactory.FlagWithValue(e.Key, e.Value), duplicateKeysHandling);
                 }
             }
             if (Segments != null)
             {
                 foreach (KeyValuePair<string, JToken> e in Segments)
                 {
-                    AddItem(allData, VersionedDataKind.Segments, FlagFactory.SegmentFromJson(e.Value));
+                    AddItem(allData, VersionedDataKind.Segments, FlagFactory.SegmentFromJson(e.Value), duplicateKeysHandling);
                 }
             }
         }
 
         private void AddItem(IDictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> allData,
-            IVersionedDataKind kind, IVersionedData item)
+            IVersionedDataKind kind, IVersionedData item, DuplicateKeysHandling duplicateKeysHandling)
         {
             IDictionary<string, IVersionedData> items;
             if (!allData.TryGetValue(kind, out items))
@@ -51,12 +53,27 @@ namespace LaunchDarkly.Client.Files
                 items = new Dictionary<string, IVersionedData>();
                 allData[kind] = items;
             }
-            if (items.ContainsKey(item.Key))
+            if (items.TryGetValue(item.Key, out IVersionedData existingItem))
             {
-                throw new System.Exception("in \"" + kind.GetNamespace() + "\", key \"" + item.Key +
-                    "\" was already defined");
+                switch (duplicateKeysHandling)
+                {
+                    case DuplicateKeysHandling.Throw:
+                        throw new System.Exception("in \"" + kind.GetNamespace() + "\", key \"" + item.Key +
+                            "\" was already defined");
+                    case DuplicateKeysHandling.OverwriteIfNewerVersion:
+                        if (item.Version > existingItem.Version)
+                        {
+                            items[item.Key] = item;
+                        }
+                        break;
+                    default:
+                        throw new NotImplementedException("Unknown duplicate keys handling: " + duplicateKeysHandling);
+                }
             }
-            items[item.Key] = item;
+            else
+            {
+                items[item.Key] = item;
+            }
         }
     }
 }

--- a/test/LaunchDarkly.ServerSdk.Tests/FlagFileDataTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/FlagFileDataTest.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using LaunchDarkly.Client;
+using LaunchDarkly.Client.Files;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class FlagFileDataTest
+    {
+        [Fact]
+        public void AddToData_DuplicateKeysHandling_Throw()
+        {
+            const string key = "flag1";
+
+            FeatureFlag initialFeatureFlag = new FeatureFlag(key, version: 0, deleted: false);
+
+            Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> data =
+                new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>
+                {
+                    {
+                        VersionedDataKind.Features,
+                        new Dictionary<string, IVersionedData>
+                        {
+                            { key, initialFeatureFlag}
+                        }
+                    }
+                };
+
+            FlagFileData fileData = new FlagFileData
+            {
+                Flags = new Dictionary<string, JToken>
+                {
+                    {
+                        key,
+                        new JObject(
+                            new JProperty("key", key),
+                            new JProperty("version", 1)
+                        )
+                    }
+                }
+            };
+
+            Exception err = Assert.Throws<Exception>(() =>
+            {
+                fileData.AddToData(data, DuplicateKeysHandling.Throw);
+            });
+            Assert.Equal("in \"features\", key \"flag1\" was already defined", err.Message);
+
+            IVersionedData postFeatureFlag = data[VersionedDataKind.Features][key];
+            Assert.Same(initialFeatureFlag, postFeatureFlag);
+            Assert.Equal(0, postFeatureFlag.Version);
+        }
+
+        [Fact]
+        public void AddToData_DuplicateKeysHandling_OverwriteWithNewerVersion()
+        {
+            const string key = "flag1";
+
+            FeatureFlag initialFeatureFlag = new FeatureFlag(key, version: 0, deleted: false);
+
+            Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> data =
+                new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>
+                {
+                    {
+                        VersionedDataKind.Features,
+                        new Dictionary<string, IVersionedData>
+                        {
+                            { key, initialFeatureFlag}
+                        }
+                    }
+                };
+
+            FlagFileData fileData = new FlagFileData
+            {
+                Flags = new Dictionary<string, JToken>
+                {
+                    {
+                        key,
+                        new JObject(
+                            new JProperty("key", key),
+                            new JProperty("version", 1)
+                        )
+                    }
+                }
+            };
+
+            fileData.AddToData(data, DuplicateKeysHandling.OverwriteIfNewerVersion);
+
+            IVersionedData postFeatureFlag = data[VersionedDataKind.Features][key];
+            Assert.NotSame(initialFeatureFlag, postFeatureFlag);
+            Assert.Equal(1, postFeatureFlag.Version);
+        }
+
+        [Fact]
+        public void AddToData_DuplicateKeysHandling_IgnoreOlderVersion()
+        {
+            const string key = "flag1";
+
+            FeatureFlag initialFeatureFlag = new FeatureFlag(key, version: 1, deleted: false);
+
+            Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> data =
+                new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>
+                {
+                    {
+                        VersionedDataKind.Features,
+                        new Dictionary<string, IVersionedData>
+                        {
+                            { key, initialFeatureFlag}
+                        }
+                    }
+                };
+
+            FlagFileData fileData = new FlagFileData
+            {
+                Flags = new Dictionary<string, JToken>
+                {
+                    {
+                        key,
+                        new JObject(
+                            new JProperty("key", key),
+                            new JProperty("version", 0)
+                        )
+                    }
+                }
+            };
+
+            fileData.AddToData(data, DuplicateKeysHandling.OverwriteIfNewerVersion);
+
+            IVersionedData postFeatureFlag = data[VersionedDataKind.Features][key];
+            Assert.Same(initialFeatureFlag, postFeatureFlag);
+            Assert.Equal(1, postFeatureFlag.Version);
+        }
+
+        [Fact]
+        public void AddToData_DuplicateKeysHandling_IgnoreSameVersion()
+        {
+            const string key = "flag1";
+
+            FeatureFlag initialFeatureFlag = new FeatureFlag(key, version: 1, deleted: false);
+
+            Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>> data =
+                new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>
+                {
+                    {
+                        VersionedDataKind.Features,
+                        new Dictionary<string, IVersionedData>
+                        {
+                            { key, initialFeatureFlag}
+                        }
+                    }
+                };
+
+            FlagFileData fileData = new FlagFileData
+            {
+                Flags = new Dictionary<string, JToken>
+                {
+                    {
+                        key,
+                        new JObject(
+                            new JProperty("key", key),
+                            new JProperty("version", 1)
+                        )
+                    }
+                }
+            };
+
+            fileData.AddToData(data, DuplicateKeysHandling.OverwriteIfNewerVersion);
+
+            IVersionedData postFeatureFlag = data[VersionedDataKind.Features][key];
+            Assert.Same(initialFeatureFlag, postFeatureFlag);
+            Assert.Equal(1, postFeatureFlag.Version);
+        }
+    }
+}


### PR DESCRIPTION
Overwriting with new version allows for graceful file rolling.

**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

I have created an enum of whether to throw on duplicates, or user the latest version.

**Describe alternatives you've considered**

I considered just always overwriting in order the files are defined, but using the latest version makes the most sense to me.
