### PR TITLE
Allowing a custom file reader be passed into FileDataSource

### DIFF
--- a/src/LaunchDarkly.ServerSdk/Files/FileDataSource.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FileDataSource.cs
@@ -15,17 +15,20 @@ namespace LaunchDarkly.Client.Files
         private readonly IDisposable _reloader;
         private readonly FlagFileParser _parser;
         private readonly FlagFileDataMerger _dataMerger;
+        private readonly IFileReader _fileReader;
         private readonly bool _skipMissingPaths;
         private volatile bool _started;
         private volatile bool _loadedValidData;
 
         public FileDataSource(IFeatureStore featureStore, List<string> paths, bool autoUpdate, TimeSpan pollInterval,
-            Func<string, object> alternateParser, bool skipMissingPaths, DuplicateKeysHandling duplicateKeysHandling)
+            Func<string, object> alternateParser, bool skipMissingPaths, DuplicateKeysHandling duplicateKeysHandling,
+            IFileReader fileReader)
         {
             _featureStore = featureStore;
             _paths = new List<string>(paths);
             _parser = new FlagFileParser(alternateParser);
             _dataMerger = new FlagFileDataMerger(duplicateKeysHandling);
+            _fileReader = fileReader;
             _skipMissingPaths = skipMissingPaths;
             if (autoUpdate)
             {
@@ -88,7 +91,7 @@ namespace LaunchDarkly.Client.Files
             {
                 try
                 {
-                    var content = ReadFileContent(path);
+                    var content = _fileReader.ReadAllText(path);
                     var data = _parser.Parse(content);
                     _dataMerger.AddToData(data, allData);
                 }
@@ -104,54 +107,6 @@ namespace LaunchDarkly.Client.Files
             }
             _featureStore.Init(allData);
             _loadedValidData = true;
-        }
-
-        private const int ReadFileRetryDelay = 200;
-        private const int ReadFileRetryAttempts = 30000 / ReadFileRetryDelay;
-
-        private static string ReadFileContent(string path)
-        {
-            int delay = 0;
-            for (int i = 0; ; i++)
-            {
-                try
-                {
-                    string content = File.ReadAllText(path);
-                    return content;
-                }
-                catch (IOException e) when (IsFileLocked(e))
-                {
-                    // Retry for approximately 30 seconds before throwing
-                    if (i > ReadFileRetryAttempts)
-                    {
-                        throw;
-                    }
-#if NETSTANDARD1_4 || NETSTANDARD1_6
-                    Task.Delay(delay).Wait();
-#else
-                    Thread.Sleep(delay);
-#endif
-                    // Retry immediately the first time but 200ms thereafter
-                    delay = ReadFileRetryDelay;
-                }
-            }
-        }
-
-        private static bool IsFileLocked(IOException exception)
-        {
-            // We cannot guarantee that these HResult values will be present on non-Windows OSes. However, this
-            // logic is less important on other platforms, because in Unix-like OSes you can atomically replace a
-            // file's contents (by creating a temporary file and then renaming it to overwrite the original file),
-            // so FileDataSource will not try to read an incomplete update; that is not possibble in Windows.
-            int errorCode = exception.HResult & 0xffff;
-            switch (errorCode)
-            {
-                case 0x20: // ERROR_SHARING_VIOLATION
-                case 0x21: // ERROR_LOCK_VIOLATION
-                    return true;
-                default:
-                    return false;
-            }
         }
 
         private void TriggerReload()

--- a/src/LaunchDarkly.ServerSdk/Files/FileDataSourceFactory.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FileDataSourceFactory.cs
@@ -21,6 +21,7 @@ namespace LaunchDarkly.Client.Files
 
         private readonly List<string> _paths = new List<string>();
         private bool _autoUpdate = false;
+        private IFileReader _fileReader = FlagFileReader.Instance;
         private TimeSpan _pollInterval = DefaultPollInterval;
         private Func<string, object> _parser = null;
         private bool _skipMissingPaths = false;
@@ -80,6 +81,17 @@ namespace LaunchDarkly.Client.Files
         public FileDataSourceFactory WithParser(Func<string, object> parseFn)
         {
             _parser = parseFn;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies an alternate file reader which can support custom OS error handling and retry logic.
+        /// </summary>
+        /// <param name="fileReader">The flag file reader.</param>
+        /// <returns>the same factory object</returns>
+        public FileDataSourceFactory WithFileReader(IFileReader fileReader)
+        {
+            _fileReader = fileReader;
             return this;
         }
 
@@ -169,7 +181,7 @@ namespace LaunchDarkly.Client.Files
         public IUpdateProcessor CreateUpdateProcessor(Configuration config, IFeatureStore featureStore)
         {
             return new FileDataSource(featureStore, _paths, _autoUpdate, _pollInterval, _parser, _skipMissingPaths,
-                _duplicateKeysHandling);
+                _duplicateKeysHandling, _fileReader);
         }
     }
 }

--- a/src/LaunchDarkly.ServerSdk/Files/FlagFileReader.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/FlagFileReader.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LaunchDarkly.Client.Files
+{
+    internal sealed class FlagFileReader : IFileReader
+    {
+        private const int ReadFileRetryDelay = 200;
+        private const int ReadFileRetryAttempts = 30000 / ReadFileRetryDelay;
+
+        private FlagFileReader() { }
+        public static readonly IFileReader Instance = new FlagFileReader();
+
+        string IFileReader.ReadAllText(string path)
+        {
+            int delay = 0;
+            for (int i = 0; ; i++)
+            {
+                try
+                {
+                    string content = File.ReadAllText(path);
+                    return content;
+                }
+                catch (IOException e) when (IsFileLocked(e))
+                {
+                    // Retry for approximately 30 seconds before throwing
+                    if (i > ReadFileRetryAttempts)
+                    {
+                        throw;
+                    }
+#if NETSTANDARD1_4 || NETSTANDARD1_6
+                    Task.Delay(delay).Wait();
+#else
+                    Thread.Sleep(delay);
+#endif
+                    // Retry immediately the first time but 200ms thereafter
+                    delay = ReadFileRetryDelay;
+                }
+            }
+        }
+
+        private static bool IsFileLocked(IOException exception)
+        {
+            // We cannot guarantee that these HResult values will be present on non-Windows OSes. However, this
+            // logic is less important on other platforms, because in Unix-like OSes you can atomically replace a
+            // file's contents (by creating a temporary file and then renaming it to overwrite the original file),
+            // so FileDataSource will not try to read an incomplete update; that is not possibble in Windows.
+            int errorCode = exception.HResult & 0xffff;
+            switch (errorCode)
+            {
+                case 0x20: // ERROR_SHARING_VIOLATION
+                case 0x21: // ERROR_LOCK_VIOLATION
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/src/LaunchDarkly.ServerSdk/Files/IFileReader.cs
+++ b/src/LaunchDarkly.ServerSdk/Files/IFileReader.cs
@@ -1,0 +1,13 @@
+﻿namespace LaunchDarkly.Client.Files
+{
+    public interface IFileReader
+    {
+        /// <summary>
+        /// Opens a text file, reads all lines of the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string containing all lines of the file.</returns>
+        /// <exception cref="System.IO.FileNotFoundException">The file specified in path was not found.</exception>
+        string ReadAllText(string path);
+    }
+}


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

I'm noticing another Windows specific race condition where a Move followed by a Delete occasionally results in an `UnauthorizedAccessException` while the file is being deleted:

```
System.UnauthorizedAccessException: Access to the path 'C:\test\previous.json' is denied.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean checkHost)
   at System.IO.File.InternalReadAllText(String path, Encoding encoding, Boolean checkHost)
   at System.IO.File.ReadAllText(String path)
```

Wrote 2 quick test apps to demonstrate.  Able to reproduce on EC2 instances routinely, but not my desktop:

https://github.com/JeffAshton/ReadAllText_UnauthorizedAccessException

**Describe the solution you've provided**

This solution allows me to customize the file reading logic to meet my tolerance.

**Describe alternatives you've considered**

I could also add handling of `UnauthorizedAccessException`, but this solution also allows me to customize the retry logic.
