### PR TITLE
Demonstrating you can use readonly record struct

### DIFF
--- a/src/LaunchDarkly.ServerSdk/Internal/Model/FeatureFlag.cs
+++ b/src/LaunchDarkly.ServerSdk/Internal/Model/FeatureFlag.cs
@@ -71,17 +71,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.Model
         Experiment
     }
 
-    internal struct VariationOrRollout
-    {
-        internal int? Variation { get; }
-        internal Rollout? Rollout { get; }
-
-        internal VariationOrRollout(int? variation, Rollout? rollout)
-        {
-            Variation = variation;
-            Rollout = rollout;
-        }
-    }
+    internal readonly record struct VariationOrRollout(int? Variation, Rollout? Rollout);
 
     internal struct WeightedVariation
     {

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -13,7 +13,7 @@
     <OutputType>Library</OutputType>
     <PackageId>LaunchDarkly.ServerSdk</PackageId>
     <RootNamespace>LaunchDarkly.Sdk.Server</RootNamespace>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Description>LaunchDarkly Server-Side .NET SDK</Description>
     <Authors>LaunchDarkly</Authors>
     <Owners>LaunchDarkly</Owners>
@@ -38,6 +38,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="5.5.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="4.1.3" />


### PR DESCRIPTION
This isn't meant to be merged.  Just proving you can benefit from C# 10.0 features and still support old target frameworks.