### PR TITLE
fix main branch name in release metadata

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -19,7 +19,7 @@ jobs:
       LD_RELEASE_TEST_TARGET_FRAMEWORK: net5.0
 
 branches:
-  - name: master
+  - name: main
     description: 6.x
   - name: 5.x
 


### PR DESCRIPTION
This change was already made in the development repo, but due to how our release flow works, we need to also make it in the public repo before we can correctly sync the two in a release.