### PR TITLE
ci: add output_path to publish-docs action

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -15,4 +15,5 @@ runs:
       name: 'Publish to Github pages'
       with:
         docs_path: ${{ inputs.workspace_path }}/docs
+        output_path: ${{ inputs.workspace_path }}
         github_token: ${{ inputs.token }}


### PR DESCRIPTION
Both packages are publishing to the same dir, clobbering each-other. This should fix it by outputting to their `workspace_path` (`pkgs/sdk/server` and `pkgs/telemetry`).