### PR TITLE
chore: Only run tests on a single thread.

### DIFF
--- a/pkgs/sdk/server/test/BaseTest.cs
+++ b/pkgs/sdk/server/test/BaseTest.cs
@@ -3,7 +3,10 @@ using System.Threading;
 using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk.Internal;
 using LaunchDarkly.Sdk.Server.Subsystems;
+using Xunit;
 using Xunit.Abstractions;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace LaunchDarkly.Sdk.Server
 {
@@ -19,7 +22,7 @@ namespace LaunchDarkly.Sdk.Server
         /// <summary>
         /// Using this <see cref="ILogAdapter"/> in an SDK configuration will cause logging to be sent
         /// to the Xunit output buffer for the current test method, if you used the overloaded
-        /// constructor <see cref="BaseTest.BaseTest(ITestOutputHelper)"/>. If you used the empty
+        /// constructor <see cref="BaseTest"/>. If you used the empty
         /// constructor, logging is disabled. Xunit only shows the buffered output for failed tests.
         /// </summary>
         /// <seealso cref="TestLogging"/>
@@ -28,7 +31,7 @@ namespace LaunchDarkly.Sdk.Server
         /// <summary>
         /// Using this <see cref="Logger"/> with an SDK component will cause logging to be sent to the
         /// Xunit output buffer for the current test method, if you used the overloaded constructor
-        /// <see cref="BaseTest.BaseTest(ITestOutputHelper)"/>. If you used the empty constructor,
+        /// <see cref="BaseTest"/>. If you used the empty constructor,
         /// logging is disabled. Xunit only shows the buffered output for failed tests.
         /// </summary>
         /// <seealso cref="TestLogging"/>

--- a/pkgs/sdk/server/test/LaunchDarkly.ServerSdk.Tests.csproj
+++ b/pkgs/sdk/server/test/LaunchDarkly.ServerSdk.Tests.csproj
@@ -43,4 +43,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/pkgs/sdk/server/test/xunit.runner.json
+++ b/pkgs/sdk/server/test/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
This is a test to see if the tests cause starvation when ran multi-threaded, which causes time dependent tests to often fail. (Not small time dependent tests, but on the order of 1-5 seconds time dependent tests.)