### PR TITLE
chore: Expect event sink to match predicate.

### DIFF
--- a/pkgs/sdk/server/test/AssertHelpers.cs
+++ b/pkgs/sdk/server/test/AssertHelpers.cs
@@ -1,4 +1,6 @@
-﻿using LaunchDarkly.Logging;
+﻿using System;
+using LaunchDarkly.Logging;
+using LaunchDarkly.TestHelpers;
 using Xunit;
 using Xunit.Sdk;
 
@@ -42,5 +44,24 @@ namespace LaunchDarkly.Sdk.Server
                     text,
                     level,
                     logCapture.ToString()));
+
+        public static void ExpectPredicate<T>(EventSink<T> sink, Predicate<T> predicate, string message, TimeSpan timeout)
+        {
+            while (true)
+            {
+                var startTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                var value = sink.ExpectValue();
+                if (predicate(value))
+                {
+                    break;
+                }
+
+                if (DateTimeOffset.Now.ToUnixTimeMilliseconds() - startTime > timeout.TotalMilliseconds)
+                {
+                    // XUnit 2.5+ adds Assert.Fail.
+                    Assert.True(false, message);
+                }
+            }
+        }
     }
 }

--- a/pkgs/sdk/server/test/AssertHelpers.cs
+++ b/pkgs/sdk/server/test/AssertHelpers.cs
@@ -64,7 +64,6 @@ namespace LaunchDarkly.Sdk.Server
             {
                 var startTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
-                Console.WriteLine("testing");
                 var value = sink.ExpectValue(timeout);
 
                 if (predicate(value))

--- a/pkgs/sdk/server/test/AssertHelpers.cs
+++ b/pkgs/sdk/server/test/AssertHelpers.cs
@@ -3,7 +3,6 @@ using LaunchDarkly.Logging;
 using LaunchDarkly.TestHelpers;
 using Xunit;
 using Xunit.Sdk;
-
 using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 using static LaunchDarkly.TestHelpers.JsonAssertions;
 
@@ -36,7 +35,8 @@ namespace LaunchDarkly.Sdk.Server
             }
         }
 
-        private static void ThrowLogMatchException(LogCapture logCapture, bool shouldHave, LogLevel level, string text, bool isRegex) =>
+        private static void ThrowLogMatchException(LogCapture logCapture, bool shouldHave, LogLevel level, string text,
+            bool isRegex) =>
             throw new AssertActualExpectedException(shouldHave, !shouldHave,
                 string.Format("Expected log {0} the {1} \"{2}\" at level {3}\n\nActual log output follows:\n{4}",
                     shouldHave ? "to have" : "not to have",
@@ -45,22 +45,38 @@ namespace LaunchDarkly.Sdk.Server
                     level,
                     logCapture.ToString()));
 
-        public static void ExpectPredicate<T>(EventSink<T> sink, Predicate<T> predicate, string message, TimeSpan timeout)
+        /// <summary>
+        /// Expect that the given sink will receive an event that passes the provided predicate within the specified
+        /// timeout.
+        ///
+        /// The total time for the execution of this method may be greater than the timeout, because its implementation
+        /// depends on a function which itself has a timeout.
+        /// </summary>
+        /// <param name="sink">the sink to check events from</param>
+        /// <param name="predicate">the predicate to run against events</param>
+        /// <param name="message">the message to show if the test fails</param>
+        /// <param name="timeout">the overall timeout</param>
+        /// <typeparam name="T">the type of the sink and predicate</typeparam>
+        public static void ExpectPredicate<T>(EventSink<T> sink, Predicate<T> predicate, string message,
+            TimeSpan timeout)
         {
             while (true)
             {
                 var startTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-                var value = sink.ExpectValue();
+
+                Console.WriteLine("testing");
+                var value = sink.ExpectValue(timeout);
+
                 if (predicate(value))
                 {
                     break;
                 }
 
-                if (DateTimeOffset.Now.ToUnixTimeMilliseconds() - startTime > timeout.TotalMilliseconds)
-                {
-                    // XUnit 2.5+ adds Assert.Fail.
-                    Assert.True(false, message);
-                }
+                if (!(DateTimeOffset.Now.ToUnixTimeMilliseconds() - startTime > timeout.TotalMilliseconds)) continue;
+
+                // XUnit 2.5+ adds Assert.Fail.
+                Assert.True(false, message);
+                return;
             }
         }
     }

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -153,7 +153,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                     AssertHelpers.ExpectPredicate(_updateSink.Inits, actual =>
                             expectedDataSet.Equals(DataSetAsJson(actual)),
                         "Did not receive expected update from the file data source.",
-                        TimeSpan.FromSeconds(5));
+                        TimeSpan.FromSeconds(30));
                 }
             }
         }

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -8,7 +8,6 @@ using LaunchDarkly.TestHelpers;
 using YamlDotNet.Serialization;
 using Xunit;
 using Xunit.Abstractions;
-
 using static LaunchDarkly.Sdk.Server.Subsystems.DataStoreTypes;
 using static LaunchDarkly.Sdk.Server.TestUtils;
 using static LaunchDarkly.TestHelpers.JsonAssertions;
@@ -24,7 +23,9 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         private readonly FileDataSourceBuilder factory = FileData.DataSource();
         private readonly Context user = Context.New("key");
 
-        public FileDataSourceTest(ITestOutputHelper testOutput) : base(testOutput) { }
+        public FileDataSourceTest(ITestOutputHelper testOutput) : base(testOutput)
+        {
+        }
 
         private IDataSource MakeDataSource() =>
             factory.Build(BasicContext.WithDataSourceUpdates(_updateSink));
@@ -148,9 +149,11 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
 
                     file.SetContentFromPath(TestUtils.TestFilePath("segment-only.json"));
 
-                    var newData = _updateSink.Inits.ExpectValue(TimeSpan.FromSeconds(5));
-
-                    AssertJsonEqual(DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2)), DataSetAsJson(newData));
+                    var expectedDataSet = DataSetAsJson(ExpectedDataSetForSegmentOnlyFile(2));
+                    AssertHelpers.ExpectPredicate(_updateSink.Inits, actual =>
+                            expectedDataSet.Equals(DataSetAsJson(actual)),
+                        "Did not receive expected update from the file data source.",
+                        TimeSpan.FromSeconds(5));
                 }
             }
         }

--- a/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
+++ b/pkgs/sdk/server/test/Internal/DataSources/FileDataSourceTest.cs
@@ -194,7 +194,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
                             }
 
                             return segment.Included[0] == "user1";
-                            return false;
                         },
                         "Did not receive expected update from the file data source.",
                         TimeSpan.FromSeconds(30));


### PR DESCRIPTION
On mac the file data source receives extra file change notifications and fails intermittently. This adds an assert helper based on a predicate that allows checking multiple events.

This helper will likely need to be used on other tests as there are some similar intermittent failures with big segments.