### PR TITLE
docs: update config example in LDClient constructor docs

### DIFF
--- a/pkgs/sdk/server/src/LdClient.cs
+++ b/pkgs/sdk/server/src/LdClient.cs
@@ -120,13 +120,7 @@ namespace LaunchDarkly.Sdk.Server
         /// <param name="config">a client configuration object (which includes an SDK key)</param>
         /// <example>
         /// <code>
-        ///     var config = Configuration.Builder("my-sdk-key")
-        ///         .Events (
-        ///           Components.SendEvents()
-        ///             .Capacity(1000)
-        ///             .AllAttributesPrivate(true)
-        ///         )
-        ///         .Build();
+        ///     var config = Configuration.Builder("my-sdk-key").Build();
         ///     var client = new LDClient(config);
         /// </code>
         /// </example>

--- a/pkgs/sdk/server/src/LdClient.cs
+++ b/pkgs/sdk/server/src/LdClient.cs
@@ -121,8 +121,11 @@ namespace LaunchDarkly.Sdk.Server
         /// <example>
         /// <code>
         ///     var config = Configuration.Builder("my-sdk-key")
-        ///         .AllAttributesPrivate(true)
-        ///         .EventCapacity(1000)
+        ///         .Events (
+        ///           Components.SendEvents()
+        ///             .Capacity(1000)
+        ///             .AllAttributesPrivate(true)
+        ///         )
         ///         .Build();
         ///     var client = new LDClient(config);
         /// </code>


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Followup to [this discussion](https://github.com/launchdarkly/ld-docs-private/pull/4382/files#r1619543723) in https://github.com/launchdarkly/ld-docs-private/pull/4382, which clarified that this example is out of date.

**Describe the solution you've provided**

Update the code sample in the LDClient constructor API docs to use `.Events` correctly.

**Describe alternatives you've considered**

If this seems confusing or too much, we could also just remove lines 124-128, and build the `Configuration` without setting any options: 

```
var config = Configuration.Builder("my-sdk-key").Build();
var client = new LDClient(config);
```

**Additional context**

previously opened as https://github.com/launchdarkly/dotnet-server-sdk-private/pull/340
