### PR TITLE
fix: Adjust big segments logic to prevent duplicate polls.

### DIFF
--- a/pkgs/sdk/server/src/Internal/BigSegments/BigSegmentStoreWrapper.cs
+++ b/pkgs/sdk/server/src/Internal/BigSegments/BigSegmentStoreWrapper.cs
@@ -25,7 +25,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.BigSegments
         private readonly Task<BigSegmentStoreStatus> _initialPoll;
 
         private BigSegmentStoreStatus? _lastStatus;
-        private int count = 0;
 
         internal event EventHandler<BigSegmentStoreStatus> StatusChanged;
 
@@ -127,11 +126,6 @@ namespace LaunchDarkly.Sdk.Server.Internal.BigSegments
 
         private async Task<BigSegmentStoreStatus> PollStoreAndUpdateStatusAsync()
         {
-            count++;
-            if (count == 2)
-            {
-                Console.WriteLine("POTATO");
-            }
             var newStatus = new BigSegmentStoreStatus();
             _logger.Debug("Querying Big Segment store metadata");
             try


### PR DESCRIPTION
The contract tests attempt to determine that the SDK is not making redundant polls, and sometimes this test would fail.

Theoretically this could also affect a server handling requests on many threads which concurrently request status before the first request has completed.